### PR TITLE
Return organization `created` field as a string

### DIFF
--- a/snyk/data_source_organization.go
+++ b/snyk/data_source_organization.go
@@ -51,7 +51,7 @@ func dataSourceOrganizationRead(ctx context.Context, d *schema.ResourceData, m i
 	}
 
 	d.Set("id", org.Id)
-	d.Set("created", org.Created)
+	d.Set("created", org.Created.String())
 	d.Set("name", org.Name)
 	d.Set("slug", org.Slug)
 	d.Set("url", org.Url)

--- a/snyk/resource_organization.go
+++ b/snyk/resource_organization.go
@@ -49,7 +49,7 @@ func resourceOrganizationCreate(ctx context.Context, d *schema.ResourceData, m i
 	}
 
 	d.SetId(org.Id)
-	d.Set("created", org.Created)
+	d.Set("created", org.Created.String())
 	d.Set("name", org.Name)
 	d.Set("slug", org.Slug)
 	d.Set("url", org.Url)
@@ -69,7 +69,7 @@ func resourceOrganizationRead(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 
-	d.Set("created", org.Created)
+	d.Set("created", org.Created.String())
 	d.Set("name", org.Name)
 	d.Set("slug", org.Slug)
 	d.Set("url", org.Url)


### PR DESCRIPTION
Fixes #65, Continues #66.

organization resource now outputs:
```terraform
{
      + created = "2021-08-16 21:32:21.692 +0000 UTC"
      + id      = "d...a"
      + name    = "S...g"
      + slug    = "s...8"
      + url     = "h...8"
    }
```